### PR TITLE
Add PEP 263 compliant coding declaration

### DIFF
--- a/src/bfa/_implementation.py
+++ b/src/bfa/_implementation.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import sys
 
 import attr


### PR DESCRIPTION
File contains non-ascii character. Python interpreter throws a syntax error: `SyntaxError: Non-ASCII character '\xe2' in file` otherwise.

[PEP 263 - Defining Source Code Encodings](https://www.python.org/dev/peps/pep-0263/)